### PR TITLE
Fix TopBar logo with external asset

### DIFF
--- a/spoonapp_flutter/README.md
+++ b/spoonapp_flutter/README.md
@@ -14,6 +14,10 @@ A few resources to get you started if this is your first Flutter project:
 Binary image assets were removed from version control. If you need the default
 app icons, run `flutter create .` inside this directory to regenerate them.
 
+The SpoonApp logo is referenced from `../static/img/spoonapp.png` so no binary
+assets are stored inside this directory. After cloning the project run
+`flutter pub get` to download the required packages.
+
 To run the sample feed:
 
 ```bash

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'dart:convert';
 import '../providers/user_provider.dart';
-import '../assets/spoonapp_logo_base64.dart';
 
 class TopBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -17,9 +15,10 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
       centerTitle: true,
       backgroundColor: Colors.transparent,
       leading: const Icon(Icons.restaurant_menu, color: Colors.white),
-      title: Image.memory(
-        base64Decode(spoonappLogoBase64),
+      title: Image.asset(
+        '../static/img/spoonapp.png',
         height: 45,
+        fit: BoxFit.contain,
       ),
       flexibleSpace: Container(
         decoration: const BoxDecoration(

--- a/spoonapp_flutter/pubspec.yaml
+++ b/spoonapp_flutter/pubspec.yaml
@@ -63,6 +63,11 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    # Use the logo from the repository root without storing a copy in this
+    # Flutter package.
+    - ../static/img/spoonapp.png
+
   # Image assets are embedded as base64 strings to avoid binary files in git.
 
   # To add assets to your application, add an assets section, like this:


### PR DESCRIPTION
## Summary
- reference shared logo asset to avoid binary files in repo
- load logo from `../static/img/spoonapp.png`
- document asset reference and `flutter pub get` in README

## Testing
- `./run_feed.sh` *(fails: `flutter` not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868213ea99c8328b735b98888e8fdb6