### PR TITLE
Improve side menu behavior on feed

### DIFF
--- a/README_FEED_MIGRATION.md
+++ b/README_FEED_MIGRATION.md
@@ -15,3 +15,5 @@ Binary assets such as icons are omitted from version control. Run `flutter creat
 `spoonapp_flutter` to regenerate the default icon set.
 
 Once Flutter is installed, execute `./run_feed.sh` to fetch packages and start the example.
+
+The feed page includes left and right side menus that slide out below the top bar. While a menu is open the feed remains fully scrollable and interactive.

--- a/spoonapp_flutter/lib/screens/feed_page.dart
+++ b/spoonapp_flutter/lib/screens/feed_page.dart
@@ -8,8 +8,19 @@ import '../widgets/sidebar_left.dart';
 import '../widgets/sidebar_right.dart';
 import 'create_post_page.dart';
 
-class FeedPage extends StatelessWidget {
+class FeedPage extends StatefulWidget {
   const FeedPage({super.key});
+
+  @override
+  State<FeedPage> createState() => _FeedPageState();
+}
+
+class _FeedPageState extends State<FeedPage> {
+  bool _leftOpen = false;
+  bool _rightOpen = false;
+
+  void _toggleLeft() => setState(() => _leftOpen = !_leftOpen);
+  void _toggleRight() => setState(() => _rightOpen = !_rightOpen);
 
   @override
   Widget build(BuildContext context) {
@@ -34,15 +45,38 @@ class FeedPage extends StatelessWidget {
       ),
     );
 
+    final body = Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showLeft) const SidebarLeft(),
+        Expanded(child: feed),
+      ],
+    );
+
     return Scaffold(
-      appBar: const TopBar(title: 'SpoonApp Social'),
-      drawer: showLeft ? null : const SidebarLeft(),
-      endDrawer: const SidebarRight(),
-      body: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      appBar: TopBar(
+        title: 'SpoonApp Social',
+        onLeftMenu: _toggleLeft,
+        onRightMenu: _toggleRight,
+      ),
+      body: Stack(
         children: [
-          if (showLeft) const SidebarLeft(),
-          Expanded(child: feed),
+          body,
+          if (!showLeft)
+            AnimatedPositioned(
+              duration: const Duration(milliseconds: 200),
+              top: 0,
+              bottom: 0,
+              left: _leftOpen ? 0 : -216,
+              child: const SidebarLeft(),
+            ),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 200),
+            top: 0,
+            bottom: 0,
+            right: _rightOpen ? 0 : -216,
+            child: const SidebarRight(),
+          ),
         ],
       ),
       floatingActionButton: Container(

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -6,7 +6,9 @@ import '../screens/profile_page.dart';
 
 class TopBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
-  const TopBar({super.key, this.title = ''});
+  final VoidCallback? onLeftMenu;
+  final VoidCallback? onRightMenu;
+  const TopBar({super.key, this.title = '', this.onLeftMenu, this.onRightMenu});
 
   @override
   Size get preferredSize => const Size.fromHeight(70);
@@ -30,8 +32,8 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
           children: [
             const SizedBox(width: 8),
             _MenuButton(
-              onPressed: () {
-                Scaffold.of(context).openDrawer();
+              onPressed: onLeftMenu ?? () {
+                Scaffold.maybeOf(context)?.openDrawer();
               },
             ),
             if (showLogo)
@@ -68,8 +70,8 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
             ),
             const SizedBox(width: 8),
             _MenuButton(
-              onPressed: () {
-                Scaffold.of(context).openEndDrawer();
+              onPressed: onRightMenu ?? () {
+                Scaffold.maybeOf(context)?.openEndDrawer();
               },
             ),
             const SizedBox(width: 8),


### PR DESCRIPTION
## Summary
- implement sliding sidebars that stay below the top bar
- allow feed interaction while side menus are open
- update feed migration notes

## Testing
- `./run_feed.sh` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682f31e4cc8328b5923489145c0f03