### PR TITLE
Fix profile info and navigation in Flutter feed

### DIFF
--- a/spoonapp_flutter/lib/models/user.dart
+++ b/spoonapp_flutter/lib/models/user.dart
@@ -1,6 +1,11 @@
 class User {
   final String name;
   final String profileImage;
+  final String email;
 
-  User({required this.name, required this.profileImage});
+  User({
+    required this.name,
+    required this.profileImage,
+    required this.email,
+  });
 }

--- a/spoonapp_flutter/lib/providers/post_provider.dart
+++ b/spoonapp_flutter/lib/providers/post_provider.dart
@@ -31,7 +31,11 @@ class PostProvider extends ChangeNotifier {
     _posts.addAll([
       Post(
         id: '1',
-        user: User(name: 'Alice', profileImage: 'https://picsum.photos/50/50?1'),
+        user: User(
+          name: 'Alice',
+          profileImage: 'https://picsum.photos/50/50?1',
+          email: 'alice@example.com',
+        ),
         date: DateTime.now().subtract(const Duration(hours: 1)),
         text: 'Hello from Flutter!',
         mediaUrl: 'https://picsum.photos/400/200?1',
@@ -39,7 +43,11 @@ class PostProvider extends ChangeNotifier {
       ),
       Post(
         id: '2',
-        user: User(name: 'Bob', profileImage: 'https://picsum.photos/50/50?2'),
+        user: User(
+          name: 'Bob',
+          profileImage: 'https://picsum.photos/50/50?2',
+          email: 'bob@example.com',
+        ),
         date: DateTime.now().subtract(const Duration(hours: 2)),
         text: 'Another post',
         mediaUrl: 'https://picsum.photos/400/200?2',
@@ -48,9 +56,21 @@ class PostProvider extends ChangeNotifier {
     ]);
 
     _activeUsers.addAll([
-      User(name: 'Alice', profileImage: 'https://picsum.photos/40/40?1'),
-      User(name: 'Bob', profileImage: 'https://picsum.photos/40/40?2'),
-      User(name: 'Charlie', profileImage: 'https://picsum.photos/40/40?3'),
+      User(
+        name: 'Alice',
+        profileImage: 'https://picsum.photos/40/40?1',
+        email: 'alice@example.com',
+      ),
+      User(
+        name: 'Bob',
+        profileImage: 'https://picsum.photos/40/40?2',
+        email: 'bob@example.com',
+      ),
+      User(
+        name: 'Charlie',
+        profileImage: 'https://picsum.photos/40/40?3',
+        email: 'charlie@example.com',
+      ),
     ]);
   }
 

--- a/spoonapp_flutter/lib/providers/user_provider.dart
+++ b/spoonapp_flutter/lib/providers/user_provider.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import '../models/user.dart';
 
 class UserProvider extends ChangeNotifier {
-  User currentUser =
-      User(name: 'Alice', profileImage: 'https://picsum.photos/50/50');
+  User currentUser = User(
+    name: 'Alice',
+    profileImage: 'https://picsum.photos/50/50',
+    email: 'alice@example.com',
+  );
 }

--- a/spoonapp_flutter/lib/screens/profile_page.dart
+++ b/spoonapp_flutter/lib/screens/profile_page.dart
@@ -1,15 +1,47 @@
 import 'package:flutter/material.dart';
 
 import '../widgets/topbar.dart';
+import 'package:provider/provider.dart';
+import '../providers/user_provider.dart';
 
 class ProfilePage extends StatelessWidget {
   const ProfilePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: TopBar(title: 'Profile'),
-      body: Center(child: Text('User Profile')),
+    final user = context.watch<UserProvider>().currentUser;
+    return Scaffold(
+      appBar: const TopBar(title: 'Profile'),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircleAvatar(
+              radius: 40,
+              backgroundImage: NetworkImage(user.profileImage),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              user.name,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            Text(
+              user.email,
+              style: const TextStyle(color: Colors.grey),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {},
+              child: const Text('Editar'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () {},
+              child: const Text('Cerrar sesi\u00f3n'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/spoonapp_flutter/lib/widgets/stories_carousel.dart
+++ b/spoonapp_flutter/lib/widgets/stories_carousel.dart
@@ -7,7 +7,13 @@ class StoriesCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFDECF5),
+        borderRadius: BorderRadius.circular(12),
+      ),
       height: 100,
       child: ListView.builder(
         scrollDirection: Axis.horizontal,
@@ -15,8 +21,9 @@ class StoriesCarousel extends StatelessWidget {
         itemBuilder: (context, index) {
           final story = stories[index];
           return Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
                 CircleAvatar(
                   backgroundImage: NetworkImage(story.mediaUrl),

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/user_provider.dart';
 import '../screens/profile_page.dart';
+import '../screens/feed_page.dart';
 
 class TopBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -51,7 +52,17 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        _NavButton(icon: Icons.home, onPressed: () {}),
+                        _NavButton(
+                          icon: Icons.home,
+                          onPressed: () {
+                            Navigator.pushReplacement(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => const FeedPage(),
+                              ),
+                            );
+                          },
+                        ),
                         _NavButton(icon: Icons.add, onPressed: () {}),
                         _NavButton(
                             icon: Icons.notifications, onPressed: () {}),


### PR DESCRIPTION
## Summary
- include email field in `User` model and sample data
- update user and post providers with email info
- show profile details and actions on `ProfilePage`
- add home navigation to feed from top bar
- display stories in a small horizontal card

## Testing
- `./run_feed.sh` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686831741aec8328abc5dcf9cff51df9