### PR TITLE
Improve Flutter feed side menus

### DIFF
--- a/spoonapp_flutter/lib/screens/feed_page.dart
+++ b/spoonapp_flutter/lib/screens/feed_page.dart
@@ -26,8 +26,6 @@ class _FeedPageState extends State<FeedPage> {
   Widget build(BuildContext context) {
     final posts = context.watch<PostProvider>().posts;
     final stories = context.watch<PostProvider>().stories;
-    final width = MediaQuery.of(context).size.width;
-    final showLeft = width > 1000;
 
     final feedContent = ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -48,7 +46,6 @@ class _FeedPageState extends State<FeedPage> {
     final body = Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (showLeft) const SidebarLeft(),
         Expanded(child: feed),
       ],
     );
@@ -62,8 +59,17 @@ class _FeedPageState extends State<FeedPage> {
       body: Stack(
         children: [
           body,
-          if (!showLeft)
-            AnimatedPositioned(
+          Positioned.fill(
+            child: IgnorePointer(
+              ignoring: true,
+              child: AnimatedOpacity(
+                opacity: _leftOpen || _rightOpen ? 0.3 : 0.0,
+                duration: const Duration(milliseconds: 200),
+                child: Container(color: Colors.black),
+              ),
+            ),
+          ),
+          AnimatedPositioned(
               duration: const Duration(milliseconds: 200),
               top: 0,
               bottom: 0,

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -40,10 +40,20 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
             if (showLogo)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: Image.asset(
-                  'assets/images/spoonapp.png',
-                  height: 45,
-                  fit: BoxFit.contain,
+                child: InkWell(
+                  onTap: () {
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const FeedPage(),
+                      ),
+                    );
+                  },
+                  child: Image.asset(
+                    'assets/images/spoonapp.png',
+                    height: 45,
+                    fit: BoxFit.contain,
+                  ),
                 ),
               ),
             Expanded(


### PR DESCRIPTION
## Summary
- make left sidebar always slide like the right one
- add dark overlay while any sidebar is open
- allow tapping the SpoonApp logo to return home

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68683727ad3c83289b3ec462c95365bc