### PR TITLE
Improve story viewer UI and carousel layout

### DIFF
--- a/spoonapp_flutter/lib/widgets/stories_carousel.dart
+++ b/spoonapp_flutter/lib/widgets/stories_carousel.dart
@@ -74,7 +74,16 @@ class StoriesCarousel extends StatelessWidget {
                       ],
                     ),
                     const SizedBox(height: 4),
-                    Text(user.name, style: const TextStyle(fontSize: 12)),
+                    SizedBox(
+                      width: 60,
+                      child: Text(
+                        user.name,
+                        style: const TextStyle(fontSize: 12),
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        maxLines: 1,
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -111,9 +120,15 @@ class StoriesCarousel extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 4),
-                  Text(
-                    story.user.name,
-                    style: const TextStyle(fontSize: 12),
+                  SizedBox(
+                    width: 60,
+                    child: Text(
+                      story.user.name,
+                      style: const TextStyle(fontSize: 12),
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                    ),
                   ),
                 ],
               ),

--- a/spoonapp_flutter/lib/widgets/story_viewer.dart
+++ b/spoonapp_flutter/lib/widgets/story_viewer.dart
@@ -95,9 +95,26 @@ class _StoryViewerState extends State<StoryViewer> {
             Positioned(
               top: 40,
               left: 16,
-              child: Text(
-                widget.stories[_current].user.name,
-                style: const TextStyle(color: Colors.white, fontSize: 16),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    radius: 16,
+                    backgroundImage: widget
+                            .stories[_current].user.profileImage
+                            .startsWith('http')
+                        ? NetworkImage(
+                            widget.stories[_current].user.profileImage)
+                        : AssetImage(
+                            widget.stories[_current].user.profileImage)
+                            as ImageProvider,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    widget.stories[_current].user.name,
+                    style:
+                        const TextStyle(color: Colors.white, fontSize: 16),
+                  ),
+                ],
               ),
             ),
             Positioned(


### PR DESCRIPTION
## Summary
- show profile avatar next to username in story viewer
- prevent overflow in stories carousel with ellipsis

## Testing
- `flutter analyze` *(fails: command not found)*
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_686850c072f483288741265ec0a991a1