### PR TITLE
Add /publish page and AWS upload flow

### DIFF
--- a/spoonapp_flutter/lib/main.dart
+++ b/spoonapp_flutter/lib/main.dart
@@ -5,6 +5,7 @@ import 'providers/post_provider.dart';
 import 'providers/user_provider.dart';
 import 'screens/feed_page.dart';
 import 'screens/splash_router.dart';
+import 'screens/create_post_page.dart';
 import 'services/backend.dart';
 
 void main() {
@@ -31,6 +32,9 @@ class SpoonApp extends StatelessWidget {
           scaffoldBackgroundColor: const Color(0xFFFFF5FA),
           useMaterial3: true,
         ),
+        routes: {
+          '/publish': (_) => const CreatePostPage(),
+        },
         home: const SplashRouter(),
       ),
     );

--- a/spoonapp_flutter/lib/screens/create_post_page.dart
+++ b/spoonapp_flutter/lib/screens/create_post_page.dart
@@ -1,14 +1,202 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:provider/provider.dart';
+import 'package:dotted_border/dotted_border.dart';
+
+import '../providers/post_provider.dart';
+import '../providers/user_provider.dart';
 import '../widgets/topbar.dart';
 
-class CreatePostPage extends StatelessWidget {
+class CreatePostPage extends StatefulWidget {
   const CreatePostPage({super.key});
 
   @override
+  State<CreatePostPage> createState() => _CreatePostPageState();
+}
+
+class _CreatePostPageState extends State<CreatePostPage> {
+  Uint8List? _fileBytes;
+  String? _fileName;
+  final _descController = TextEditingController();
+  String? _category;
+  bool _loading = false;
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['png', 'jpg', 'jpeg', 'mp4'],
+    );
+    if (result != null && result.files.single.bytes != null) {
+      setState(() {
+        _fileBytes = result.files.single.bytes;
+        _fileName = result.files.single.name;
+      });
+    }
+  }
+
+  Future<void> _publish() async {
+    if (_loading || _fileBytes == null || _category == null) return;
+    final userProv = context.read<UserProvider>();
+    setState(() => _loading = true);
+    try {
+      await context.read<PostProvider>().addPost(
+            userProv.currentUser,
+            _fileBytes!,
+            _fileName ?? 'media',
+            _descController.text,
+            _category!,
+            userProv.token,
+          );
+      if (mounted) Navigator.pop(context);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Error al publicar')));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: TopBar(title: 'Create Post'),
-      body: Center(child: Text('Create Post')),
+    final width = MediaQuery.of(context).size.width;
+    final boxWidth = width > 800 ? 800.0 : width * 0.9;
+    return Scaffold(
+      appBar: const TopBar(title: 'Crear publicación'),
+      body: Container(
+        width: double.infinity,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFFB46DDD), Color(0xFFD9A7C7)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Container(
+              width: boxWidth,
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: const Color(0xB3E6E6FA),
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Colors.black26,
+                    blurRadius: 8,
+                    offset: Offset(0, 4),
+                  )
+                ],
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  GestureDetector(
+                    onTap: _pickFile,
+                    child: DottedBorder(
+                      color: Colors.white70,
+                      strokeWidth: 2,
+                      dashPattern: const [6, 4],
+                      borderType: BorderType.RRect,
+                      radius: const Radius.circular(8),
+                      child: Container(
+                        height: 150,
+                        alignment: Alignment.center,
+                        color: _fileBytes == null
+                            ? Colors.transparent
+                            : Colors.white24,
+                        child: _fileBytes == null
+                            ? Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                mainAxisSize: MainAxisSize.min,
+                                children: const [
+                                  Icon(Icons.attach_file, color: Colors.grey),
+                                  SizedBox(width: 8),
+                                  Text(
+                                    '🖱️ Arrastra una imagen o video aquí o haz clic',
+                                    style: TextStyle(color: Colors.grey),
+                                  ),
+                                ],
+                              )
+                            : Image.memory(_fileBytes!, fit: BoxFit.cover),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _descController,
+                    minLines: 3,
+                    maxLines: null,
+                    decoration: const InputDecoration(
+                      filled: true,
+                      fillColor: Color(0xFFEFE3F6),
+                      hintText: '🧑‍🍳 ¿Qué tienes en tu cuchara?',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<String>(
+                    value: _category,
+                    decoration: const InputDecoration(
+                      filled: true,
+                      fillColor: Color(0xFFEFE3F6),
+                      hintText: 'Selecciona la categoría de tu plato 🍲',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.all(Radius.circular(8)),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    items: const [
+                      DropdownMenuItem(value: 'Entrantes', child: Text('Entrantes')),
+                      DropdownMenuItem(value: 'Primer plato', child: Text('Primer plato')),
+                      DropdownMenuItem(value: 'Segundo plato', child: Text('Segundo plato')),
+                      DropdownMenuItem(value: 'Postres', child: Text('Postres')),
+                    ],
+                    onChanged: (v) => setState(() => _category = v),
+                  ),
+                  const SizedBox(height: 16),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: ElevatedButton.icon(
+                      onPressed: (_fileBytes == null || _category == null || _loading)
+                          ? null
+                          : _publish,
+                      icon: _loading
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Text('🚀'),
+                      label: const Text('Publicar'),
+                      style: ElevatedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 24, vertical: 12),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        backgroundColor: const Color(0xFFB46DDD),
+                      ).copyWith(
+                        elevation: MaterialStateProperty.resolveWith(
+                          (states) => states.contains(MaterialState.hovered) ? 6 : 2,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/spoonapp_flutter/lib/screens/feed_page.dart
+++ b/spoonapp_flutter/lib/screens/feed_page.dart
@@ -88,8 +88,7 @@ class _FeedPageState extends State<FeedPage> {
         child: IconButton(
           icon: const Icon(Icons.add, color: Colors.white),
           onPressed: () {
-            Navigator.push(
-                context, MaterialPageRoute(builder: (_) => const CreatePostPage()));
+            Navigator.pushNamed(context, '/publish');
           },
         ),
       ),

--- a/spoonapp_flutter/lib/services/backend.dart
+++ b/spoonapp_flutter/lib/services/backend.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import '../models/story.dart';
 import '../models/user.dart';
+import '../models/post.dart';
 
 class BackendService {
   final String baseUrl;
@@ -43,5 +44,48 @@ class BackendService {
     }
     final response = await request.send();
     return response.statusCode == 200;
+  }
+
+  Future<Map<String, dynamic>?> uploadPost(Uint8List bytes, String filename,
+      String description, String category, String token) async {
+    final uri = Uri.parse('$baseUrl/api/posts/upload/');
+    final request = http.MultipartRequest('POST', uri);
+    final ext = filename.split('.').last.toLowerCase();
+    final isVideo = ['mp4', 'mov', 'avi', 'webm'].contains(ext);
+    request.fields['description'] = description;
+    request.fields['category'] = category;
+    request.fields['token'] = token;
+    if (isVideo) {
+      request.files.add(
+        http.MultipartFile.fromBytes('video', bytes, filename: filename),
+      );
+    } else {
+      request.files.add(
+        http.MultipartFile.fromBytes('image', bytes, filename: filename),
+      );
+    }
+    final response = await request.send();
+    if (response.statusCode != 200) return null;
+    final body = await response.stream.bytesToString();
+    return jsonDecode(body) as Map<String, dynamic>;
+  }
+
+  Future<List<Post>> fetchPosts() async {
+    final resp = await http.get(Uri.parse('$baseUrl/api/posts/'));
+    if (resp.statusCode != 200) return [];
+    final jsonList = jsonDecode(resp.body)['posts'] as List<dynamic>;
+    return jsonList.map((p) {
+      return Post(
+        id: p['id'],
+        user: User(
+          name: p['user_name'],
+          profileImage: p['avatar'] ?? '',
+          email: p['email'] ?? '',
+        ),
+        date: DateTime.parse(p['created_at']),
+        text: p['description'] ?? '',
+        mediaUrl: p['url'],
+      );
+    }).toList();
   }
 }

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -75,7 +75,12 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
                             );
                           },
                         ),
-                        _NavButton(icon: Icons.add, onPressed: () {}),
+                        _NavButton(
+                          icon: Icons.add,
+                          onPressed: () {
+                            Navigator.pushNamed(context, '/publish');
+                          },
+                        ),
                         _NavButton(
                             icon: Icons.notifications, onPressed: () {}),
                         _NavButton(icon: Icons.restaurant, onPressed: () {}),

--- a/spoonapp_flutter/pubspec.yaml
+++ b/spoonapp_flutter/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   palette_generator: ^0.3.3+7
+  dotted_border: ^3.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- route topbar `+` icon and FAB to named `/publish` route
- implement publish page with file picker, description, category and publish button
- add DynamoDB/S3 integration in backend API for posts
- extend provider and backend service to upload and fetch posts
- define `/publish` route in Flutter app and include dotted_border package

## Testing
- `python -m py_compile backend/main.py`
- _No Dart/Flutter available to run static analysis_


------
https://chatgpt.com/codex/tasks/task_e_6868786fbdc88328ba4bf4797a1fb1cb