### PR TITLE
Improve publish page

### DIFF
--- a/spoonapp_flutter/lib/main.dart
+++ b/spoonapp_flutter/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'providers/post_provider.dart';
 import 'providers/user_provider.dart';
+import 'providers/menu_provider.dart';
 import 'screens/feed_page.dart';
 import 'screens/splash_router.dart';
 import 'screens/create_post_page.dart';
@@ -22,6 +23,7 @@ class SpoonApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => UserProvider()),
         ChangeNotifierProvider(
             create: (_) => PostProvider(BackendService('http://localhost:8000'))),
+        ChangeNotifierProvider(create: (_) => MenuProvider()),
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
@@ -29,7 +31,7 @@ class SpoonApp extends StatelessWidget {
         theme: ThemeData(
           fontFamily: GoogleFonts.lato().fontFamily,
           colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFB46DDD)),
-          scaffoldBackgroundColor: const Color(0xFFFFF5FA),
+          scaffoldBackgroundColor: const Color(0xFFFFFFF5),
           useMaterial3: true,
         ),
         routes: {

--- a/spoonapp_flutter/lib/providers/menu_provider.dart
+++ b/spoonapp_flutter/lib/providers/menu_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class MenuProvider extends ChangeNotifier {
+  bool _leftOpen = false;
+  bool _rightOpen = false;
+
+  bool get leftOpen => _leftOpen;
+  bool get rightOpen => _rightOpen;
+
+  void toggleLeft() {
+    _leftOpen = !_leftOpen;
+    notifyListeners();
+  }
+
+  void toggleRight() {
+    _rightOpen = !_rightOpen;
+    notifyListeners();
+  }
+}

--- a/spoonapp_flutter/lib/screens/create_post_page.dart
+++ b/spoonapp_flutter/lib/screens/create_post_page.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
@@ -8,6 +9,9 @@ import 'package:dotted_border/dotted_border.dart';
 import '../providers/post_provider.dart';
 import '../providers/user_provider.dart';
 import '../widgets/topbar.dart';
+import '../widgets/sidebar_left.dart';
+import '../widgets/sidebar_right.dart';
+import '../providers/menu_provider.dart';
 
 class CreatePostPage extends StatefulWidget {
   const CreatePostPage({super.key});
@@ -22,6 +26,9 @@ class _CreatePostPageState extends State<CreatePostPage> {
   final _descController = TextEditingController();
   String? _category;
   bool _loading = false;
+
+  void _toggleLeft() => context.read<MenuProvider>().toggleLeft();
+  void _toggleRight() => context.read<MenuProvider>().toggleRight();
 
   Future<void> _pickFile() async {
     final result = await FilePicker.platform.pickFiles(
@@ -64,138 +71,155 @@ class _CreatePostPageState extends State<CreatePostPage> {
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     final boxWidth = width > 800 ? 800.0 : width * 0.9;
-    return Scaffold(
-      appBar: const TopBar(title: 'Crear publicación'),
-      body: Container(
-        width: double.infinity,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFFB46DDD), Color(0xFFD9A7C7)],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
+    final menu = context.watch<MenuProvider>();
+
+    final card = ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+        child: Container(
+          width: boxWidth,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              colors: [Color(0xFFB46DDD), Color(0xFFD9A7C7)],
+            ),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white70, width: 1.5),
+            boxShadow: const [
+              BoxShadow(color: Colors.black26, blurRadius: 8, offset: Offset(0, 4)),
+            ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              GestureDetector(
+                onTap: _pickFile,
+                child: DottedBorder(
+                  color: Colors.white70,
+                  strokeWidth: 2,
+                  dashPattern: const [6, 4],
+                  borderType: BorderType.RRect,
+                  radius: const Radius.circular(8),
+                  child: Container(
+                    height: 150,
+                    alignment: Alignment.center,
+                    color: _fileBytes == null ? Colors.transparent : Colors.white24,
+                    child: _fileBytes == null
+                        ? Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
+                            children: const [
+                              Icon(Icons.attach_file, color: Colors.grey),
+                              SizedBox(width: 8),
+                              Text(
+                                '🖱️ Arrastra una imagen o video aquí o haz clic',
+                                style: TextStyle(color: Colors.grey),
+                              ),
+                            ],
+                          )
+                        : Image.memory(_fileBytes!, fit: BoxFit.cover),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _descController,
+                minLines: 3,
+                maxLines: null,
+                decoration: const InputDecoration(
+                  filled: true,
+                  fillColor: Color(0xFFEFE3F6),
+                  hintText: '🧑‍🍳 ¿Qué tienes en tu cuchara?',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                value: _category,
+                decoration: const InputDecoration(
+                  filled: true,
+                  fillColor: Color(0xFFEFE3F6),
+                  hintText: 'Selecciona la categoría de tu plato 🍲',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(8)),
+                    borderSide: BorderSide.none,
+                  ),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'Entrantes', child: Text('Entrantes')),
+                  DropdownMenuItem(value: 'Primer plato', child: Text('Primer plato')),
+                  DropdownMenuItem(value: 'Segundo plato', child: Text('Segundo plato')),
+                  DropdownMenuItem(value: 'Postres', child: Text('Postres')),
+                ],
+                onChanged: (v) => setState(() => _category = v),
+              ),
+              const SizedBox(height: 16),
+              Align(
+                alignment: Alignment.centerRight,
+                child: ElevatedButton.icon(
+                  onPressed:
+                      (_fileBytes == null || _category == null || _loading) ? null : _publish,
+                  icon: _loading
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('🚀'),
+                  label: const Text('Publicar'),
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    backgroundColor: const Color(0xFFB46DDD),
+                  ).copyWith(
+                    elevation: MaterialStateProperty.resolveWith(
+                      (states) => states.contains(MaterialState.hovered) ? 6 : 2,
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
-        child: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Container(
-              width: boxWidth,
+      ),
+    );
+
+    return Scaffold(
+      appBar: TopBar(
+        title: 'Crear publicación',
+        onLeftMenu: _toggleLeft,
+        onRightMenu: _toggleRight,
+      ),
+      body: Stack(
+        children: [
+          Center(
+            child: SingleChildScrollView(
               padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: const Color(0xB3E6E6FA),
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: const [
-                  BoxShadow(
-                    color: Colors.black26,
-                    blurRadius: 8,
-                    offset: Offset(0, 4),
-                  )
-                ],
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  GestureDetector(
-                    onTap: _pickFile,
-                    child: DottedBorder(
-                      color: Colors.white70,
-                      strokeWidth: 2,
-                      dashPattern: const [6, 4],
-                      borderType: BorderType.RRect,
-                      radius: const Radius.circular(8),
-                      child: Container(
-                        height: 150,
-                        alignment: Alignment.center,
-                        color: _fileBytes == null
-                            ? Colors.transparent
-                            : Colors.white24,
-                        child: _fileBytes == null
-                            ? Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                mainAxisSize: MainAxisSize.min,
-                                children: const [
-                                  Icon(Icons.attach_file, color: Colors.grey),
-                                  SizedBox(width: 8),
-                                  Text(
-                                    '🖱️ Arrastra una imagen o video aquí o haz clic',
-                                    style: TextStyle(color: Colors.grey),
-                                  ),
-                                ],
-                              )
-                            : Image.memory(_fileBytes!, fit: BoxFit.cover),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: _descController,
-                    minLines: 3,
-                    maxLines: null,
-                    decoration: const InputDecoration(
-                      filled: true,
-                      fillColor: Color(0xFFEFE3F6),
-                      hintText: '🧑‍🍳 ¿Qué tienes en tu cuchara?',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(8)),
-                        borderSide: BorderSide.none,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  DropdownButtonFormField<String>(
-                    value: _category,
-                    decoration: const InputDecoration(
-                      filled: true,
-                      fillColor: Color(0xFFEFE3F6),
-                      hintText: 'Selecciona la categoría de tu plato 🍲',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.all(Radius.circular(8)),
-                        borderSide: BorderSide.none,
-                      ),
-                    ),
-                    items: const [
-                      DropdownMenuItem(value: 'Entrantes', child: Text('Entrantes')),
-                      DropdownMenuItem(value: 'Primer plato', child: Text('Primer plato')),
-                      DropdownMenuItem(value: 'Segundo plato', child: Text('Segundo plato')),
-                      DropdownMenuItem(value: 'Postres', child: Text('Postres')),
-                    ],
-                    onChanged: (v) => setState(() => _category = v),
-                  ),
-                  const SizedBox(height: 16),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: ElevatedButton.icon(
-                      onPressed: (_fileBytes == null || _category == null || _loading)
-                          ? null
-                          : _publish,
-                      icon: _loading
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Text('🚀'),
-                      label: const Text('Publicar'),
-                      style: ElevatedButton.styleFrom(
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 24, vertical: 12),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(24),
-                        ),
-                        backgroundColor: const Color(0xFFB46DDD),
-                      ).copyWith(
-                        elevation: MaterialStateProperty.resolveWith(
-                          (states) => states.contains(MaterialState.hovered) ? 6 : 2,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+              child: card,
             ),
           ),
-        ),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 200),
+            top: 0,
+            bottom: 0,
+            left: menu.leftOpen ? 0 : -216,
+            child: const SidebarLeft(),
+          ),
+          AnimatedPositioned(
+            duration: const Duration(milliseconds: 200),
+            top: 0,
+            bottom: 0,
+            right: menu.rightOpen ? 0 : -216,
+            child: const SidebarRight(),
+          ),
+        ],
       ),
     );
   }

--- a/spoonapp_flutter/lib/screens/feed_page.dart
+++ b/spoonapp_flutter/lib/screens/feed_page.dart
@@ -6,7 +6,7 @@ import '../widgets/stories_carousel.dart';
 import '../widgets/topbar.dart';
 import '../widgets/sidebar_left.dart';
 import '../widgets/sidebar_right.dart';
-import 'create_post_page.dart';
+import '../providers/menu_provider.dart';
 
 class FeedPage extends StatefulWidget {
   const FeedPage({super.key});
@@ -16,16 +16,14 @@ class FeedPage extends StatefulWidget {
 }
 
 class _FeedPageState extends State<FeedPage> {
-  bool _leftOpen = false;
-  bool _rightOpen = false;
-
-  void _toggleLeft() => setState(() => _leftOpen = !_leftOpen);
-  void _toggleRight() => setState(() => _rightOpen = !_rightOpen);
+  void _toggleLeft() => context.read<MenuProvider>().toggleLeft();
+  void _toggleRight() => context.read<MenuProvider>().toggleRight();
 
   @override
   Widget build(BuildContext context) {
     final posts = context.watch<PostProvider>().posts;
     final stories = context.watch<PostProvider>().stories;
+    final menu = context.watch<MenuProvider>();
 
     final feedContent = ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),
@@ -63,14 +61,14 @@ class _FeedPageState extends State<FeedPage> {
             duration: const Duration(milliseconds: 200),
             top: 0,
             bottom: 0,
-            left: _leftOpen ? 0 : -216,
+            left: menu.leftOpen ? 0 : -216,
             child: const SidebarLeft(),
           ),
           AnimatedPositioned(
             duration: const Duration(milliseconds: 200),
             top: 0,
             bottom: 0,
-            right: _rightOpen ? 0 : -216,
+            right: menu.rightOpen ? 0 : -216,
             child: const SidebarRight(),
           ),
         ],


### PR DESCRIPTION
## Summary
- keep left/right drawer state between screens
- allow toggling the drawers on the publish page
- theme background uses a subtle yellow

## Testing
- `dart format lib/main.dart lib/providers/menu_provider.dart lib/screens/feed_page.dart lib/screens/create_post_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687d617a6c8328a795b337f0f7db7c