### PR TITLE
Add missing MenuProvider

### DIFF
--- a/spoonapp_flutter/lib/main.dart
+++ b/spoonapp_flutter/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'providers/post_provider.dart';
 import 'providers/user_provider.dart';
+import 'providers/menu_provider.dart';
 import 'screens/feed_page.dart';
 import 'screens/splash_router.dart';
 import 'screens/create_post_page.dart';
@@ -22,6 +23,7 @@ class SpoonApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => UserProvider()),
         ChangeNotifierProvider(
             create: (_) => PostProvider(BackendService('http://localhost:8000'))),
+        ChangeNotifierProvider(create: (_) => MenuProvider()),
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,


### PR DESCRIPTION
## Summary
- include `MenuProvider` import and provider registration

## Testing
- `flutter test` *(fails: command not found)*
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6868853a416c8328ad20aa5b1c1de417