### PR TITLE
Update create post UI with glass design

### DIFF
--- a/spoonapp_flutter/lib/main.dart
+++ b/spoonapp_flutter/lib/main.dart
@@ -31,7 +31,7 @@ class SpoonApp extends StatelessWidget {
         theme: ThemeData(
           fontFamily: GoogleFonts.lato().fontFamily,
           colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFB46DDD)),
-          scaffoldBackgroundColor: const Color(0xFFFFF5FA),
+          scaffoldBackgroundColor: const Color(0xFFFFFDF4),
           useMaterial3: true,
         ),
         routes: {

--- a/spoonapp_flutter/lib/screens/create_post_page.dart
+++ b/spoonapp_flutter/lib/screens/create_post_page.dart
@@ -82,14 +82,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
           width: boxWidth,
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                const Color(0xFFB46DDD).withOpacity(0.25),
-                const Color(0xFFD9A7C7).withOpacity(0.25),
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
+            color: Colors.white.withOpacity(0.2),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(color: Colors.white.withOpacity(0.3), width: 1),
             boxShadow: [
@@ -100,10 +93,18 @@ class _CreatePostPageState extends State<CreatePostPage> {
                 offset: const Offset(0, 10),
               ),
             ],
+            gradient: LinearGradient(
+              colors: [
+                Colors.white.withOpacity(0.05),
+                Colors.white.withOpacity(0.0),
+              ],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ),
           ),
           child: DefaultTextStyle(
-            style: TextStyle(
-              color: Colors.white.withOpacity(0.9),
+            style: const TextStyle(
+              color: Colors.black,
               fontWeight: FontWeight.w500,
             ),
             child: Column(
@@ -114,20 +115,27 @@ class _CreatePostPageState extends State<CreatePostPage> {
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(12),
                     child: DottedBorder(
+                      color: Colors.black45,
+                      strokeWidth: 1.5,
+                      borderType: BorderType.RRect,
+                      radius: const Radius.circular(12),
+                      dashPattern: const [6, 3],
                       child: Container(
                         height: 150,
                         alignment: Alignment.center,
-                        color: _fileBytes == null ? Colors.transparent : Colors.white24,
+                        color: _fileBytes == null
+                            ? Colors.transparent
+                            : Colors.white24,
                         child: _fileBytes == null
                             ? Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 mainAxisSize: MainAxisSize.min,
                                 children: const [
-                                  Icon(Icons.attach_file, color: Colors.grey),
+                                  Icon(Icons.attach_file, color: Colors.black54),
                                   SizedBox(width: 8),
                                   Text(
                                     '🖱️ Arrastra una imagen o video aquí o haz clic',
-                                    style: TextStyle(color: Colors.grey),
+                                    style: TextStyle(color: Colors.black54),
                                   ),
                                 ],
                               )
@@ -141,11 +149,13 @@ class _CreatePostPageState extends State<CreatePostPage> {
                   controller: _descController,
                   minLines: 3,
                   maxLines: null,
-                  decoration: const InputDecoration(
+                  style: const TextStyle(color: Colors.black),
+                  decoration: InputDecoration(
                     filled: true,
-                    fillColor: Color(0xFFF8F5FF),
+                    fillColor: Colors.white.withOpacity(0.3),
                     hintText: '🧑‍🍳 ¿Qué tienes en tu cuchara?',
-                    border: OutlineInputBorder(
+                    hintStyle: const TextStyle(color: Colors.black54),
+                    border: const OutlineInputBorder(
                       borderRadius: BorderRadius.all(Radius.circular(12)),
                       borderSide: BorderSide.none,
                     ),
@@ -154,29 +164,34 @@ class _CreatePostPageState extends State<CreatePostPage> {
                 const SizedBox(height: 16),
                 DropdownButtonFormField<String>(
                   value: _category,
-                  decoration: const InputDecoration(
+                  decoration: InputDecoration(
                     filled: true,
-                    fillColor: Color(0xFFF8F5FF),
+                    fillColor: Colors.white.withOpacity(0.3),
                     hintText: 'Selecciona la categoría de tu plato 🍲',
-                    border: OutlineInputBorder(
+                    hintStyle: const TextStyle(color: Colors.black54),
+                    border: const OutlineInputBorder(
                       borderRadius: BorderRadius.all(Radius.circular(12)),
                       borderSide: BorderSide.none,
                     ),
                   ),
+                  iconEnabledColor: Colors.black,
                   items: const [
                     DropdownMenuItem(
                       value: 'Entrantes',
-                      child: Text('Entrantes'),
+                      child: Text('Entrantes', style: TextStyle(color: Colors.black)),
                     ),
                     DropdownMenuItem(
                       value: 'Primer plato',
-                      child: Text('Primer plato'),
+                      child: Text('Primer plato', style: TextStyle(color: Colors.black)),
                     ),
                     DropdownMenuItem(
                       value: 'Segundo plato',
-                      child: Text('Segundo plato'),
+                      child: Text('Segundo plato', style: TextStyle(color: Colors.black)),
                     ),
-                    DropdownMenuItem(value: 'Postres', child: Text('Postres')),
+                    DropdownMenuItem(
+                      value: 'Postres',
+                      child: Text('Postres', style: TextStyle(color: Colors.black)),
+                    ),
                   ],
                   onChanged: (v) => setState(() => _category = v),
                 ),
@@ -194,14 +209,14 @@ class _CreatePostPageState extends State<CreatePostPage> {
                             height: 16,
                             child: CircularProgressIndicator(
                               strokeWidth: 2,
-                              color: Colors.white,
+                              color: Colors.black,
                             ),
                           )
-                        : const Text('🚀'),
+                        : const Icon(Icons.rocket_launch, color: Colors.black),
                     label: const Text('Publicar'),
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFFB46DDD),
-                      foregroundColor: Colors.white,
+                      backgroundColor: Colors.white.withOpacity(0.2),
+                      foregroundColor: Colors.black,
                       padding: const EdgeInsets.symmetric(
                         horizontal: 24,
                         vertical: 12,
@@ -209,6 +224,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(24),
                       ),
+                      elevation: 0,
                     ),
                   ),
                 ),

--- a/spoonapp_flutter/lib/widgets/sidebar_left.dart
+++ b/spoonapp_flutter/lib/widgets/sidebar_left.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 
 class SidebarLeft extends StatelessWidget {
@@ -5,82 +6,93 @@ class SidebarLeft extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 200,
-      margin: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFDECF5),
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 4)],
-      ),
-      child: ListView(
-        padding: const EdgeInsets.all(8),
-        children: [
-          const Text('Men\u00fa', style: TextStyle(fontWeight: FontWeight.bold)),
-          const ListTile(
-            leading: Icon(Icons.videocam),
-            title: Text('Transmisiones'),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+        child: Container(
+          width: 200,
+          margin: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFF4CC).withOpacity(0.2),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white.withOpacity(0.3), width: 1),
+            boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 10)],
           ),
-          const ListTile(
-            leading: Icon(Icons.event),
-            title: Text('Eventos'),
-          ),
-          const ListTile(
-            leading: Icon(Icons.people),
-            title: Text('Usuarios'),
-          ),
-          const ListTile(
-            leading: Icon(Icons.memory),
-            title: Text('Recuerdos'),
-          ),
-          const ListTile(
-            leading: Icon(Icons.videogame_asset),
-            title: Text('Juegos'),
-          ),
-          const Divider(),
-          const Text('Restaurantes',
-              style: TextStyle(fontWeight: FontWeight.bold)),
-          ListTile(
-            leading: const Icon(Icons.restaurant),
-            title: const Text("Luigi's Kitchen"),
-            trailing:
-                const Text('Ir al sitio', style: TextStyle(color: Colors.blue)),
-            onTap: () {},
-          ),
-          ListTile(
-            leading: const Icon(Icons.restaurant),
-            title: const Text('Restaurant 2'),
-            trailing:
-                const Text('Ir al sitio', style: TextStyle(color: Colors.blue)),
-            onTap: () {},
-          ),
-          ListTile(
-            leading: const Icon(Icons.restaurant),
-            title: const Text('Restaurant 3'),
-            trailing:
-                const Text('Ir al sitio', style: TextStyle(color: Colors.blue)),
-            onTap: () {},
-          ),
-          ListTile(
-            leading: const Icon(Icons.restaurant),
-            title: const Text('Restaurant 4'),
-            trailing:
-                const Text('Ir al sitio', style: TextStyle(color: Colors.blue)),
-            onTap: () {},
-          ),
-          const SizedBox(height: 8),
-          TextButton(
-            onPressed: () {},
-            style: TextButton.styleFrom(
-              backgroundColor: const Color(0xFFD699C7),
-              foregroundColor: Colors.white,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8),
-              ),
+          child: DefaultTextStyle(
+            style: const TextStyle(color: Colors.black),
+            child: ListView(
+              padding: const EdgeInsets.all(8),
+              children: [
+                const Text('Men\u00fa',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                const ListTile(
+                  leading: Icon(Icons.videocam, color: Colors.black),
+                  title: Text('Transmisiones'),
+                ),
+                const ListTile(
+                  leading: Icon(Icons.event, color: Colors.black),
+                  title: Text('Eventos'),
+                ),
+                const ListTile(
+                  leading: Icon(Icons.people, color: Colors.black),
+                  title: Text('Usuarios'),
+                ),
+                const ListTile(
+                  leading: Icon(Icons.memory, color: Colors.black),
+                  title: Text('Recuerdos'),
+                ),
+                const ListTile(
+                  leading: Icon(Icons.videogame_asset, color: Colors.black),
+                  title: Text('Juegos'),
+                ),
+                const Divider(),
+                const Text('Restaurantes',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                ListTile(
+                  leading: const Icon(Icons.restaurant, color: Colors.black),
+                  title: const Text("Luigi's Kitchen"),
+                  trailing: const Text('Ir al sitio',
+                      style: TextStyle(color: Colors.blue)),
+                  onTap: () {},
+                ),
+                ListTile(
+                  leading: const Icon(Icons.restaurant, color: Colors.black),
+                  title: const Text('Restaurant 2'),
+                  trailing: const Text('Ir al sitio',
+                      style: TextStyle(color: Colors.blue)),
+                  onTap: () {},
+                ),
+                ListTile(
+                  leading: const Icon(Icons.restaurant, color: Colors.black),
+                  title: const Text('Restaurant 3'),
+                  trailing: const Text('Ir al sitio',
+                      style: TextStyle(color: Colors.blue)),
+                  onTap: () {},
+                ),
+                ListTile(
+                  leading: const Icon(Icons.restaurant, color: Colors.black),
+                  title: const Text('Restaurant 4'),
+                  trailing: const Text('Ir al sitio',
+                      style: TextStyle(color: Colors.blue)),
+                  onTap: () {},
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () {},
+                  style: TextButton.styleFrom(
+                    backgroundColor: Colors.white.withOpacity(0.2),
+                    foregroundColor: Colors.black,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                  child: const Text('Ver m\u00e1s'),
+                ),
+              ],
             ),
-            child: const Text('Ver m\u00e1s'),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/spoonapp_flutter/lib/widgets/sidebar_right.dart
+++ b/spoonapp_flutter/lib/widgets/sidebar_right.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/post_provider.dart';
@@ -7,34 +8,48 @@ class SidebarRight extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 200,
-      margin: const EdgeInsets.all(8),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFFF0F5),
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 4)],
-      ),
-      child: ListView(
-        padding: const EdgeInsets.all(8),
-        children: [
-          const Text('Usuarios activos', style: TextStyle(fontWeight: FontWeight.bold)),
-          const SizedBox(height: 8),
-          ...context.watch<PostProvider>().activeUsers.map(
-            (u) => ListTile(
-              leading: CircleAvatar(backgroundImage: NetworkImage(u.profileImage)),
-              title: Text(u.name),
-              subtitle: const Text('Activo'),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(16),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+        child: Container(
+          width: 200,
+          margin: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFF4CC).withOpacity(0.2),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Colors.white.withOpacity(0.3), width: 1),
+            boxShadow: const [BoxShadow(color: Colors.black26, blurRadius: 10)],
+          ),
+          child: DefaultTextStyle(
+            style: const TextStyle(color: Colors.black),
+            child: ListView(
+              padding: const EdgeInsets.all(8),
+              children: [
+                const Text('Usuarios activos',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                ...context.watch<PostProvider>().activeUsers.map(
+                  (u) => ListTile(
+                    leading: CircleAvatar(
+                        backgroundImage: NetworkImage(u.profileImage)),
+                    title: Text(u.name),
+                    subtitle: const Text('Activo'),
+                  ),
+                ),
+                const Divider(),
+                const Text('Comunidades',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                const ListTile(title: Text('Cocina')),
+                const ListTile(title: Text('Viajes')),
+                const Divider(),
+                const Text('Patrocinados',
+                    style: TextStyle(fontWeight: FontWeight.bold)),
+                const ListTile(title: Text('Anuncio 1')),
+              ],
             ),
           ),
-          const Divider(),
-          const Text('Comunidades', style: TextStyle(fontWeight: FontWeight.bold)),
-          const ListTile(title: Text('Cocina')),
-          const ListTile(title: Text('Viajes')),
-          const Divider(),
-          const Text('Patrocinados', style: TextStyle(fontWeight: FontWeight.bold)),
-          const ListTile(title: Text('Anuncio 1')),
-        ],
+        ),
       ),
     );
   }

--- a/spoonapp_flutter/lib/widgets/topbar.dart
+++ b/spoonapp_flutter/lib/widgets/topbar.dart
@@ -154,15 +154,20 @@ class _MenuButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      color: const Color(0xFFFFF0B3),
-      shape: const CircleBorder(),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onPressed,
-        child: const Padding(
-          padding: EdgeInsets.all(8),
-          child: Icon(Icons.menu, color: Color(0xFF5D1049)),
+    return ClipOval(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+        child: Material(
+          color: Colors.white.withOpacity(0.2),
+          shape: const CircleBorder(),
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onPressed,
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Icon(Icons.menu, color: Colors.black),
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- use new pale background theme
- redesign create-post card with glass aesthetic and black text
- style inputs, dropdown and publish button for clarity
- give sidebars and menu buttons a glassy look

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688b6080d4832896e793de464d345d