### PR TITLE
Improve post creation card styling

### DIFF
--- a/spoonapp_flutter/lib/screens/create_post_page.dart
+++ b/spoonapp_flutter/lib/screens/create_post_page.dart
@@ -82,25 +82,23 @@ class _CreatePostPageState extends State<CreatePostPage> {
           width: boxWidth,
           padding: const EdgeInsets.all(20),
           decoration: BoxDecoration(
-            color: const Color(0xFFFF00FF).withOpacity(0.25),
+            gradient: LinearGradient(
+              colors: [
+                const Color(0xFFB46DDD).withOpacity(0.45),
+                const Color(0xFFD9A7C7).withOpacity(0.45),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
             borderRadius: BorderRadius.circular(20),
             border: Border.all(color: Colors.white.withOpacity(0.3), width: 1),
             boxShadow: [
               BoxShadow(
-                color: Colors.white54,
+                color: Colors.black.withOpacity(0.15),
                 blurRadius: 20,
-                spreadRadius: 1,
-                offset: const Offset(0, 10),
+                offset: const Offset(0, 8),
               ),
             ],
-            gradient: LinearGradient(
-              colors: [
-                Colors.white.withOpacity(0.05),
-                Colors.white.withOpacity(0.0),
-              ],
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-            ),
           ),
           child: DefaultTextStyle(
             style: const TextStyle(
@@ -118,7 +116,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                       child: Container(
                         height: 150,
                         alignment: Alignment.center,
-                        color: const Color(0xFFFF00FF).withOpacity(0.2),
+                        color: const Color(0xFFB46DDD).withOpacity(0.2),
                         child: _fileBytes == null
                             ? Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
@@ -145,7 +143,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                   style: const TextStyle(color: Colors.black),
                   decoration: InputDecoration(
                     filled: true,
-                    fillColor: const Color(0xFFFF00FF).withOpacity(0.3),
+                    fillColor: const Color(0xFFB46DDD).withOpacity(0.15),
                     hintText: '🧑‍🍳 ¿Qué tienes en tu cuchara?',
                     hintStyle: const TextStyle(color: Colors.black54),
                     border: const OutlineInputBorder(
@@ -159,7 +157,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                   value: _category,
                   decoration: InputDecoration(
                     filled: true,
-                    fillColor: const Color(0xFFFF00FF).withOpacity(0.3),
+                    fillColor: const Color(0xFFB46DDD).withOpacity(0.15),
                     hintText: 'Selecciona la categoría de tu plato 🍲',
                     hintStyle: const TextStyle(color: Colors.black54),
                     border: const OutlineInputBorder(
@@ -209,7 +207,7 @@ class _CreatePostPageState extends State<CreatePostPage> {
                     label: const Text('Publicar'),
                     style: ElevatedButton.styleFrom(
                       backgroundColor:
-                          const Color(0xFFFF00FF).withOpacity(0.3),
+                          const Color(0xFFB46DDD).withOpacity(0.3),
                       foregroundColor: Colors.black,
                       padding: const EdgeInsets.symmetric(
                         horizontal: 24,


### PR DESCRIPTION
## Summary
- add lilac glassmorphism style to the post creation card

## Testing
- `flutter test` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689053470083288563425461d61a0d